### PR TITLE
Problem with `tqdm_notebook`and `tqdm` format in `core.py`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ numpy == 1.16.4
 pandas == 0.24.2
 scipy == 1.0.0
 setuptools == 20.7.0
-tqdm == 4.19.6
+tqdm == 4.45.0

--- a/svd2vec/core.py
+++ b/svd2vec/core.py
@@ -13,7 +13,7 @@ from scipy.sparse.linalg import svds
 from scipy.stats import pearsonr
 from joblib import Parallel, delayed
 from collections import OrderedDict, Counter
-from tqdm import tqdm, tqdm_notebook
+from tqdm import tqdm, notebook 
 
 from .utils import Utils
 from .window import WindowWeights
@@ -210,8 +210,8 @@ class svd2vec:
             # solves a bug in jupyter notebooks
             # https://github.com/tqdm/tqdm/issues/485#issuecomment-473338308
             print('\r', end='', flush=True)
-        func   = tqdm_notebook if notebook else tqdm
-        format = None if notebook else "{desc: <30} {percentage:3.0f}%  {bar}"
+        func   = notebook.tqdm_notebook if notebook else tqdm
+        format = "{desc: <30} {percentage:3.0f}%  {bar}"
         return func(
             iterable=yielder,
             desc=desc,


### PR DESCRIPTION
Fixed problem with `tqdm_notebook`:
* Proper import of `tqdm.notebook.tqdm_notebook`
* Fixed `tqdm` version in requirements

Fixed problem with `None` object for `tqdm` format of progressbar in notebook.